### PR TITLE
Add bottom navigation with horizontal section scrolling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var wrapper = document.getElementById('horizontal-wrapper');
+  var buttons = document.querySelectorAll('.bottom-nav button');
+
+  buttons.forEach(function (button) {
+    button.addEventListener('click', function () {
+      var index = button.dataset.index;
+      wrapper.style.transform = 'translateX(-' + index * 100 + 'vw)';
+    });
+  });
+});
+

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,42 @@
+/* Minimal theme styles */
+body {
+  margin: 0;
+  padding: 0;
+  font-family: sans-serif;
+  overflow-x: hidden;
+}
+
+#horizontal-wrapper {
+  display: flex;
+  width: 400vw;
+  transition: transform 0.3s ease;
+}
+
+.panel {
+  flex: 0 0 100vw;
+  height: 100vh;
+  overflow-y: auto;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+  background: rgba(255,255,255,0.9);
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.bottom-nav button {
+  background: none;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -1,0 +1,6 @@
+{
+  "current": "Default",
+  "presets": {
+    "Default": {}
+  }
+}

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "Theme settings",
+    "settings": []
+  }
+]

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ page_title }}</title>
+  {{ content_for_header }}
+  <link rel="stylesheet" href="{{ 'style.css' | asset_url }}">
+</head>
+<body>
+  {{ content_for_layout }}
+
+  <div class="bottom-nav">
+    <button data-index="0">Produkte</button>
+    <button data-index="1">Konfigurator</button>
+    <button data-index="2">Warenkorb</button>
+    <button data-index="3">Mehr</button>
+  </div>
+
+  <script src="{{ 'app.js' | asset_url }}"></script>
+</body>
+</html>

--- a/templates/index.liquid
+++ b/templates/index.liquid
@@ -1,0 +1,15 @@
+<div id="horizontal-wrapper">
+  <section class="panel" id="produkte">
+    <h2>Produkte</h2>
+  </section>
+  <section class="panel" id="konfigurator">
+    <h2>Konfigurator</h2>
+  </section>
+  <section class="panel" id="warenkorb">
+    <h2>Warenkorb</h2>
+  </section>
+  <section class="panel" id="mehr">
+    <h2>Mehr</h2>
+  </section>
+</div>
+


### PR DESCRIPTION
## Summary
- add floating bottom navigation with four buttons
- enable button-controlled horizontal scrolling through four sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c74001fc83239ff302e669c73e67