### PR TITLE
Add configurable bottom navigation container

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -6,22 +6,35 @@ body {
   background-color: #f0f0f0;
 }
 
-.bottom-nav {
+.bottom-nav-container {
   position: fixed;
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
+  padding: var(--bottom-nav-padding, 0.5rem);
+  background-color: #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  width: calc(100% - 40px);
+  max-width: var(--bottom-nav-max-width, 500px);
+}
+
+.bottom-nav {
   display: flex;
-  gap: 1rem;
+  gap: var(--bottom-nav-gap, 1rem);
 }
 
 @media (max-width: 768px) {
-  .bottom-nav {
+  .bottom-nav-container {
     bottom: 0;
     left: 0;
     right: 0;
     transform: none;
     width: 100%;
+    border-radius: 0;
+  }
+
+  .bottom-nav {
     justify-content: space-around;
   }
 }

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -1,6 +1,10 @@
 {
   "current": "Default",
   "presets": {
-    "Default": {}
+    "Default": {
+      "bottom_nav_gap": 16,
+      "bottom_nav_padding": 8,
+      "bottom_nav_max_width": 500
+    }
   }
 }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1,1 +1,37 @@
-[]
+[
+  {
+    "name": "Bottom navigation",
+    "settings": [
+      {
+        "type": "range",
+        "id": "bottom_nav_gap",
+        "label": "Button spacing",
+        "min": 0,
+        "max": 40,
+        "step": 1,
+        "unit": "px",
+        "default": 16
+      },
+      {
+        "type": "range",
+        "id": "bottom_nav_padding",
+        "label": "Box padding",
+        "min": 0,
+        "max": 40,
+        "step": 1,
+        "unit": "px",
+        "default": 8
+      },
+      {
+        "type": "range",
+        "id": "bottom_nav_max_width",
+        "label": "Max box width",
+        "min": 200,
+        "max": 800,
+        "step": 10,
+        "unit": "px",
+        "default": 500
+      }
+    ]
+  }
+]

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -6,16 +6,25 @@
   <title>{{ page_title }}</title>
   {{ content_for_header }}
   <link rel="stylesheet" href="{{ 'style.css' | asset_url }}">
+  <style>
+    :root {
+      --bottom-nav-gap: {{ settings.bottom_nav_gap | default: 16 }}px;
+      --bottom-nav-padding: {{ settings.bottom_nav_padding | default: 8 }}px;
+      --bottom-nav-max-width: {{ settings.bottom_nav_max_width | default: 500 }}px;
+    }
+  </style>
 </head>
 <body>
   {{ content_for_layout }}
   <p>hi</p>
-  <nav class="bottom-nav">
-    <button id="btn-products">Produkte</button>
-    <button id="btn-config">Konfigurator</button>
-    <button id="btn-cart">Warenkorb</button>
-    <button id="btn-more">Mehr</button>
-  </nav>
+  <div class="bottom-nav-container">
+    <nav class="bottom-nav">
+      <button id="btn-products">Produkte</button>
+      <button id="btn-config">Konfigurator</button>
+      <button id="btn-cart">Warenkorb</button>
+      <button id="btn-more">Mehr</button>
+    </nav>
+  </div>
   <script src="{{ 'bottom-nav.js' | asset_url }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Wrap bottom navigation buttons in a container with adjustable padding and max width
- Make gap between bottom navigation buttons configurable
- Expose spacing, padding, and width controls in theme settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8d89985d88323bfd6b3fdd7ea2237